### PR TITLE
Development instructions + link from README + additional make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,15 @@
+.PHONY: fmt
+fmt:
+	rye fmt
+
+.PHONY: lint
+lint:
+	rye lint
+
+.PHONY: test
+test:
+	rye test
+
+.PHONY: typecheck
 typecheck:
 	rye run mypy -p src.riverqueue

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # River client for Python
 
-An insert-only Python client for [River](https://github.com/riverqueue).
+An insert-only Python client for [River](https://github.com/riverqueue/river) packaged in the [`riverqueue` gem](https://rubygems.org/gems/riverqueue). Allows jobs to be inserted in Python and run by a Go worker, but doesn't support working jobs in Python.
+
+## Development
+
+See [development](./docs/development.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,47 @@
+# riverqueue-python development
+
+## Install dependencies
+
+The project uses [Rye](https://github.com/astral-sh/rye) for its development toolchain and to run development targets. Install it with:
+
+```shell
+$ curl -sSf https://rye.astral.sh/get | bash
+```
+
+Or via Homebrew:
+
+```shell
+$ brew install rye
+```
+
+Then use it to set up a virtual environment:
+
+```shell
+$ rye sync
+```
+
+## Run tests
+
+```shell
+$ rye test
+```
+
+## Run lint
+
+```shell
+$ rye lint
+```
+
+## Run type check (Mypy)
+
+```shell
+$ make typecheck
+```
+
+## Format code
+
+```shell
+$ rye fmt
+```
+
+Rye uses [Ruff](https://github.com/astral-sh/ruff) under the hood for code formatting.


### PR DESCRIPTION
A few miscellaneous changes that are largely documentation related:

* Add `docs/development.md` containing basic instructions on how to
  install dependencies, run tests, run lint, run code formatting, etc.
  This matches convention in other River projects and makes it easier
  for people to bootstrap themselves when they're not deeply familiar
  with Python's conventions already.

* Link `docs/development.md` from top-level README. This pull originally
  proposed also moving the README to `docs/` for consistency with other
  River projects, but apparently Rye does not allow this.

* Add some additional make targets for other development tasks beyond
  the type check. Again, not strictly necessary, but sort of nice
  because it means you don't have to remember which targets need to use
  make versus which need to use Rye -- you can just `make` anything and
  it'll work. Also, make all targets Phony [1].

[1] https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
